### PR TITLE
Fix exploding market_list partial due to failed Integer conversion

### DIFF
--- a/app/views/markets/_market_list.html.erb
+++ b/app/views/markets/_market_list.html.erb
@@ -42,7 +42,7 @@
             <% @data.fetch(:markets).each do |market| %>
               <tr class="markets-toggle" id="market-list-<%= market.fetch(:id) %>" data-quote-unit="<%= market.fetch(:bid_unit) %>" data-base-unit="<%= market.fetch(:ask_unit) %>" data-market="<%= market[:id] %>">
                 <td class="col-xs-4 name">
-                  <%= link_to market.fetch(:name), '/trading/' + market.fetch(:id) %>
+                  <%= link_to market.fetch(:name), "/trading/#{market.fetch(:id)}" %>
                 </td>
                 <td class="col-xs-15 price">
                   <%= market.fetch(:ticker).fetch(:last) %>


### PR DESCRIPTION
Seeing this error on the market_list partial:

`no implicit conversion of Integer into String`

Happens on this line, because id is an integer:

`<%= link_to market.fetch(:name), '/trading/' + market.fetch(:id) %>`

Stack trace:

```
app/views/markets/_market_list.html.erb:45:in `+'
app/views/markets/_market_list.html.erb:45:in `block in _app_views_markets__market_list_html_erb___1114354424198798529_70278936648000'
app/views/markets/_market_list.html.erb:42:in `each'
```